### PR TITLE
Fix IRC configuration setting domain with Synapse homeserver

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 ops==2.17.1
 pydantic==2.10.5
 cryptography==44.0.0
+requests==2.32.3

--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -30,7 +30,7 @@ ircService:
       botConfig:
         enabled: true
         nick: "UbuntuLiberaBot"
-        username: "ubunbtuliberabot"
+        username: "ubuntuliberabot"
         joinChannelsIfNoUsers: true
       privateMessages:
         enabled: true

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -15,6 +15,12 @@ from pytest_operator.plugin import OpsTest
 import tests.integration.helpers
 
 
+@fixture(scope="module", name="matrix_homeserver")
+def matrix_homeserver():
+    """Provide Matrix homeserver."""
+    yield "https://example.com"
+
+
 @fixture(scope="module", name="metadata")
 def fixture_metadata():
     """Provide charm metadata."""


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Currently, only [homeserver][URL] is set with the value provided by the matrix-auth integration, but it is also necessary to change the "[domain](https://github.com/matrix-org/matrix-appservice-irc/blob/062f3ace8b08e86e9f63c004ffdb85942af1b94e/config.sample.yaml#L21).

This PR fixes that and also validates the change in the integration test.

### Rationale

Since the Matrix homeserver URL could be different from the homeserver name itself (chat-server.example.com is the URL and example.com is the servername), the charm will check the homeserver name by calling the [publishing keys](https://spec.matrix.org/v1.13/server-server-api/#publishing-keys) API. If fails, then the homeserver URL domain will be used.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
