### PR TITLE
Expose ident port

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -21,6 +21,7 @@ from matrix_observer import MatrixObserver
 logger = logging.getLogger(__name__)
 
 IRC_BIND_PORT = 8090
+IDENT_PORT = 113
 
 
 class IRCCharm(ops.CharmBase):
@@ -128,6 +129,9 @@ class IRCCharm(ops.CharmBase):
             self.unit.status = ops.MaintenanceStatus(f"Invalid configuration: {e}")
             logger.exception("Invalid configuration: {%s}", e)
             return
+        if config.ident_enabled:
+            logger.info("Ident is enabled, exposing port %d", IDENT_PORT)
+            self.unit.set_ports(IDENT_PORT)
         self._irc.reconcile(db, matrix, config, self._get_external_url())
         self._matrix.set_irc_registration(self._irc.get_registration())
         self.unit.status = ops.ActiveStatus()

--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -82,7 +82,7 @@ ircService:
     initial: false
   ident:
     enabled: true
-    port: 1113
+    port: 113
     address: "::"
   logging:
     level: "debug"

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1,13 +1,49 @@
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""Unit tests for the charm."""
+"""Unit tests for the IRC Bridge charm."""
+
+# Ignore similar lines with database_observer.
+# pylint: disable=R0801
+
+from unittest.mock import MagicMock
+
+import ops
+from ops.testing import Harness
+from pytest import MonkeyPatch
+
+from charm import IDENT_PORT, IRCCharm
 
 
-def test_nothing():
+def test_irc_bridge_ident(monkeypatch: MonkeyPatch) -> None:
     """
-    arrange: nothing.
-    act: nothing.
-    assert: True.
+    arrange: start the charm with all integrations and commands mocked.
+    act: change ident_enabled config to true.
+    assert: The port is exposed and the charm is active.
     """
-    assert True
+    harness = Harness(IRCCharm)
+    harness.add_network("10.0.0.10")
+    harness.add_relation("matrix-auth", "synapse", app_data={"homeserver": "123"})
+    harness.add_relation(
+        "database",
+        "database-provider",
+        app_data={
+            "database": "ircbridge",
+            "endpoints": "postgresql-k8s-primary.local:5432",
+            "password": "123",
+            "username": "user1",
+        },
+    )
+    harness.begin()
+    monkeypatch.setattr(harness.charm, "_irc", MagicMock())
+    monkeypatch.setattr(harness.charm, "_matrix", MagicMock())
+    harness.set_leader(True)
+    harness.update_config({"bot_nickname": "testbot", "bridge_admins": "admin:example.com"})
+    assert isinstance(harness.model.unit.status, ops.ActiveStatus)
+    # Empty since ident is disabled by default
+    assert harness.model.unit.opened_ports() == set()
+
+    harness.update_config({"ident_enabled": True})
+
+    assert isinstance(harness.model.unit.status, ops.ActiveStatus)
+    assert ops.Port(protocol="tcp", port=IDENT_PORT) in harness.model.unit.opened_ports()


### PR DESCRIPTION
Applicable spec: <link>

### Overview

We need to expose Ident port since will be requested/used by Libera.
Also, this PR changes to the default value 113.

### Rationale

Fix integration between Libera/Ident (IRC bridge).

### Juju Events Changes

config-changed: when ident is enabled, expose the port.

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
