### PR TITLE
Fix bridge_admins validation

### DIFF
--- a/tests/unit/test_charm_types.py
+++ b/tests/unit/test_charm_types.py
@@ -5,7 +5,10 @@
 
 from secrets import token_hex
 
-from charm_types import DatasourcePostgreSQL
+import pytest
+from pydantic import ValidationError
+
+from charm_types import CharmConfig, DatasourcePostgreSQL
 
 
 def test_datasource_postgresql():
@@ -32,3 +35,56 @@ def test_datasource_postgresql():
     assert datasource.port == port
     assert datasource.db == db
     assert datasource.uri == uri
+
+
+@pytest.mark.parametrize(
+    "data, expected_output, expect_error",
+    [
+        # Success case
+        pytest.param(
+            {
+                "ident_enabled": True,
+                "bot_nickname": "test_bot",
+                "bridge_admins": "user1:example.com,user2:banana.test.fruits.com",
+            },
+            {
+                "ident_enabled": True,
+                "bot_nickname": "test_bot",
+                "bridge_admins": ["@user1:example.com", "@user2:banana.test.fruits.com"],
+            },
+            False,
+            id="valid_user_ids",
+        ),
+        # Validation error case
+        pytest.param(
+            {
+                "ident_enabled": True,
+                "bot_nickname": "test_bot",
+                "bridge_admins": "invalid_user_id,user2:example.com",
+            },
+            None,
+            True,
+            id="invalid_user_id",
+        ),
+    ],
+)
+def test_charm_config(data, expected_output, expect_error):
+    """Test the CharmConfig class.
+
+    arrange: Create a CharmConfig instance.
+    act: Change attributes.
+    assert: The attributes are validate and the same as the input values.
+    """
+    if expect_error:
+        try:
+            CharmConfig(**data)
+        except ValidationError as e:
+            error_message = str(e)
+            assert "Invalid user ID format" in error_message
+        else:
+            assert False, "ValidationError was not raised for invalid user ID."
+    else:
+        charm_config = CharmConfig(**data)
+        assert charm_config.ident_enabled == expected_output["ident_enabled"]
+        assert charm_config.bot_nickname == expected_output["bot_nickname"]
+        assert charm_config.bridge_admins == expected_output["bridge_admins"]


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Currently the bridge_admin does not accept subdomains.

### Rationale

This PR fixes the validation for accepting users such as "user1:domain1.domain2.com"

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
