### PR TITLE
Fix how registration file is generated

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### 2025-02-25
 
 - Ensure that the registration file is updated when the configuration changes.
+- Ensure that the media proxy key file is generated only once.
+- Change default media proxy public URL to "https://media-not-supported/media".
 
 ### 2025-02-13
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2025-02-25
+
+- Ensure that the registration file is updated when the configuration changes.
+
 ### 2025-02-13
 
 - Add changelog for tracking user-relevant changes.

--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -126,7 +126,7 @@ ircService:
     signingKeyPath: "/data/config/signingkey.jwk"
     ttlSeconds: 3600
     bindPort: 11111
-    publicUrl: "https://irc.bridge/media"
+    publicUrl: "https://media-not-supported/media"
   userActivity:
     minUserActiveDays: 1
     inactiveAfterDays: 30

--- a/tests/unit/test_irc.py
+++ b/tests/unit/test_irc.py
@@ -287,6 +287,24 @@ def test_configure_generates_app_registration_local(irc_bridge_service, mocker, 
         assert registration_file_path.exists(), f"Expected {registration_file_path} to exist"
 
 
+def test_skip_media_proxy_key(irc_bridge_service, mocker, tmp_path: Path):
+    """Test that the _generate_media_proxy_key method not generates the key file
+        if already exists.
+
+    arrange: Prepare a mock for the subprocess.run method.
+    act: Call the _generate_media_proxy_key method.
+    assert: Ensure that the subprocess.run method was not called.
+    """
+    signing_key_file_path = tmp_path / "signing.key"
+    signing_key_file_path.touch()
+    with patch("irc.IRC_BRIDGE_SIGNING_KEY_FILE_PATH", signing_key_file_path):
+        mock_run = mocker.patch.object(subprocess, "run")
+
+        irc_bridge_service._generate_media_proxy_key()  # pylint: disable=protected-access
+
+        mock_run.assert_not_called()
+
+
 def test_configure_evaluates_configuration_file_local(irc_bridge_service, mocker):
     """Test that the _eval_conf_local method evaluates the configuration file.
 

--- a/tests/unit/test_irc.py
+++ b/tests/unit/test_irc.py
@@ -21,7 +21,6 @@ from constants import (
     IRC_BRIDGE_KEY_ALGO,
     IRC_BRIDGE_KEY_OPTS,
     IRC_BRIDGE_PEM_FILE_PATH,
-    IRC_BRIDGE_REGISTRATION_FILE_PATH,
     IRC_BRIDGE_SERVICE_NAME,
     IRC_BRIDGE_SNAP_NAME,
 )
@@ -248,39 +247,44 @@ def test_configure_generates_pem_file_local(irc_bridge_service, mocker):
     # pylint: enable=duplicate-code
 
 
-def test_configure_generates_app_registration_local(irc_bridge_service, mocker):
+def test_configure_generates_app_registration_local(irc_bridge_service, mocker, tmp_path: Path):
     """Test that the _generate_app_registration_local method generates the app registration file.
 
     arrange: Prepare a mock for the subprocess.run method.
     act: Call the _generate_app_registration_local method.
     assert: Ensure that the subprocess.run method was called with the correct arguments.
     """
-    mock_run = mocker.patch.object(subprocess, "run")
+    registration_file_path = tmp_path / "appservice-registration-irc.yaml"
+    Path(str(registration_file_path) + ".tmp").touch()
+    with patch("irc.IRC_BRIDGE_REGISTRATION_FILE_PATH", registration_file_path):
+        mock_run = mocker.patch.object(subprocess, "run")
+        config = CharmConfig(
+            ident_enabled=True,
+            bot_nickname="my_bot",
+            bridge_admins="admin1:example.com,admin2:example.com",
+        )
+        assert (
+            not registration_file_path.exists()
+        ), f"Expected {registration_file_path} not to exist before running the command"
 
-    config = CharmConfig(
-        ident_enabled=True,
-        bot_nickname="my_bot",
-        bridge_admins="admin1:example.com,admin2:example.com",
-    )
+        irc_bridge_service._generate_app_registration_local(  # pylint: disable=protected-access
+            config, "http://localhost:8090"
+        )
 
-    irc_bridge_service._generate_app_registration_local(  # pylint: disable=protected-access
-        config, "http://localhost:8090"
-    )
-
-    # pylint: disable=duplicate-code
-    mock_run.assert_called_once_with(
-        [
-            "/bin/bash",
-            "-c",
-            f"[[ -f {IRC_BRIDGE_REGISTRATION_FILE_PATH} ]] || "
-            f"snap run matrix-appservice-irc -r -f {IRC_BRIDGE_REGISTRATION_FILE_PATH}"
-            f" -u http://localhost:8090 "
-            f"-c {IRC_BRIDGE_CONFIG_FILE_PATH} -l {config.bot_nickname}",
-        ],
-        check=True,
-        capture_output=True,
-    )
-    # pylint: enable=duplicate-code
+        # pylint: disable=duplicate-code
+        mock_run.assert_called_once_with(
+            [
+                "/bin/bash",
+                "-c",
+                f"snap run matrix-appservice-irc -r -f {registration_file_path}.tmp"
+                f" -u http://localhost:8090 "
+                f"-c {IRC_BRIDGE_CONFIG_FILE_PATH} -l {config.bot_nickname}",
+            ],
+            check=True,
+            capture_output=True,
+        )
+        # pylint: enable=duplicate-code
+        assert registration_file_path.exists(), f"Expected {registration_file_path} to exist"
 
 
 def test_configure_evaluates_configuration_file_local(irc_bridge_service, mocker):


### PR DESCRIPTION
Applicable spec: <link>

### Overview

This PR changes how the registration file is generated by creating a temporary file and only renaming it to the expected location if the command succeeds.
Also guarantees that the media proxy key file is generated only if not found.

Minor: changes default public media URL to "https://media-not-supported/media" for now.

The way that was set before, the file was generated only if didn't exist.

### Rationale

Fix how configuration changes are handled and guarantee that media proxy key is not replaced.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
