### PR TITLE
Add ingress for media proxy

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -28,3 +28,6 @@ requires:
   ingress:
     interface: ingress
     limit: 1
+  ingress-media:
+    interface: ingress
+    limit: 1

--- a/src/charm.py
+++ b/src/charm.py
@@ -107,7 +107,7 @@ class IRCCharm(ops.CharmBase):
             unit_ip = str(binding.network.bind_address)
             external_url = f"http://{unit_ip}:{IRC_MEDIA_BIND_PORT}"
         # If ingress media is set, get ingress url
-        if self.ingress_media:
+        if self.ingress_media.url:
             external_url = self.ingress_media.url
         return external_url
 

--- a/src/irc.py
+++ b/src/irc.py
@@ -3,6 +3,9 @@
 
 """IRC Bridge charm business logic."""
 
+# Reconcile and further methods require URLs from ingress integrations.
+# pylint: disable=too-many-positional-arguments, too-many-arguments
+
 import logging
 import shutil
 import subprocess  # nosec
@@ -103,6 +106,7 @@ class IRCBridgeService:
         matrix: MatrixAuthProviderData,
         config: CharmConfig,
         external_url: str,
+        media_external_url: str,
     ) -> None:
         """Reconcile the service.
 
@@ -116,9 +120,10 @@ class IRCBridgeService:
             matrix: the matrix configuration
             config: the charm configuration
             external_url: ingress url (or unit IP)
+            media_external_url: media ingress url (or unit IP)
         """
         self.prepare()
-        self.configure(db, matrix, config, external_url)
+        self.configure(db, matrix, config, external_url, media_external_url)
         self.reload()
 
     def prepare(self) -> None:
@@ -173,6 +178,7 @@ class IRCBridgeService:
         matrix: MatrixAuthProviderData,
         config: CharmConfig,
         external_url: str,
+        media_external_url: str,
     ) -> None:
         """Configure the service.
 
@@ -181,10 +187,11 @@ class IRCBridgeService:
             matrix: the matrix configuration
             config: the charm configuration
             external_url: ingress url (or unit IP)
+            media_external_url: media ingress url (or unit IP)
         """
         self._generate_pem_file_local()
         self._generate_app_registration_local(config, external_url)
-        self._eval_conf_local(db, matrix, config)
+        self._eval_conf_local(db, matrix, config, media_external_url)
 
     def _generate_pem_file_local(self) -> None:
         """Generate the PEM file content."""
@@ -237,7 +244,11 @@ class IRCBridgeService:
         logger.info("Media proxy key file creation result: %s", result)
 
     def _eval_conf_local(
-        self, db: DatasourcePostgreSQL, matrix: MatrixAuthProviderData, config: CharmConfig
+        self,
+        db: DatasourcePostgreSQL,
+        matrix: MatrixAuthProviderData,
+        config: CharmConfig,
+        media_external_url: str,
     ) -> None:
         """Generate the content of the irc configuration file.
 
@@ -245,6 +256,7 @@ class IRCBridgeService:
             db: the database configuration
             matrix: the matrix configuration
             config: the charm configuration
+            media_external_url: media ingress url (or unit IP)
 
         Raises:
             SynapseConfigurationFileError: when encountering a KeyError from the configuration file
@@ -260,6 +272,7 @@ class IRCBridgeService:
             data["ircService"]["mediaProxy"][
                 "signingKeyPath"
             ] = f"{IRC_BRIDGE_SIGNING_KEY_FILE_PATH}"
+            data["ircService"]["mediaProxy"]["publicUrl"] = media_external_url
             data["ircService"]["passwordEncryptionKeyPath"] = f"{IRC_BRIDGE_PEM_FILE_PATH}"
             data["ircService"]["ident"]["enabled"] = config.ident_enabled
             data["ircService"]["permissions"] = {}

--- a/src/irc.py
+++ b/src/irc.py
@@ -190,6 +190,10 @@ class IRCBridgeService:
             media_external_url: media ingress url (or unit IP)
         """
         self._generate_pem_file_local()
+        # First re-generate configuration in case something is not ok
+        # otherwise generate_app_registration_local fails if
+        # configuration file is invalid
+        self._eval_conf_local(db, matrix, config, media_external_url)
         self._generate_app_registration_local(config, external_url)
         self._eval_conf_local(db, matrix, config, media_external_url)
 

--- a/tests/integration/test_ingress.py
+++ b/tests/integration/test_ingress.py
@@ -95,7 +95,7 @@ async def test_ingress_media_integration(app_integrated: Application, model: Mod
     await model.wait_for_idle(
         apps=[self_signed_application.name, haproxy_application.name], status="active"
     )
-    await model.add_relation(app_integrated.name, haproxy_application.name)
+    await model.add_relation(f"{app_integrated.name}:ingress-media", haproxy_application.name)
     await model.wait_for_idle(
         apps=[app_integrated.name, haproxy_application.name], status="active"
     )

--- a/tests/integration/test_ingress.py
+++ b/tests/integration/test_ingress.py
@@ -61,3 +61,50 @@ async def test_ingress_integration(app_integrated: Application, model: Model):
 
     assert response.status_code == 200
     assert response.text == "OK"
+
+
+@pytest.mark.asyncio
+@pytest.mark.abort_on_fail
+async def test_ingress_media_integration(app_integrated: Application, model: Model):
+    """
+    arrange: assert IRC Media /health is ok, deploy haproxy and relate it to
+        self-signed-certificates. Relate haproxy with IRC bridge.
+    act: request /health via haproxy.
+    assert: request is successful.
+    """
+    unit_address = await tests.integration.helpers.get_unit_address(app_integrated)
+    unit_address = unit_address.removeprefix("http://")
+    response = requests.get(f"http://{unit_address}:11111/health", timeout=30)
+    assert response.status_code == 200
+    assert response.headers.get("Content-Type") == "application/json"
+    assert response.json() == {"ok": True}
+    haproxy_application = await model.deploy("haproxy", channel="2.8/edge")
+    self_signed_application = await model.deploy("self-signed-certificates", channel="edge")
+    external_hostname = "haproxy-media.internal"
+    await haproxy_application.set_config({"external-hostname": external_hostname})
+    await model.wait_for_idle(
+        apps=[self_signed_application.name, haproxy_application.name], status="active"
+    )
+    await model.add_relation(self_signed_application.name, haproxy_application.name)
+    await model.wait_for_idle(
+        apps=[self_signed_application.name, haproxy_application.name], status="active"
+    )
+    await model.add_relation(app_integrated.name, haproxy_application.name)
+    await model.wait_for_idle(
+        apps=[app_integrated.name, haproxy_application.name], status="active"
+    )
+
+    unit_address = await tests.integration.helpers.get_unit_address(haproxy_application)
+    unit_address = unit_address.removeprefix("http://")
+    session = Session()
+    session.mount("https://", DNSResolverHTTPSAdapter(external_hostname, str(unit_address)))
+    response = session.get(
+        f"https://{unit_address}/{model.name}-{app_integrated.name}/health",
+        headers={"Host": external_hostname},
+        verify=False,  # nosec - calling charm ingress URL
+        timeout=30,
+    )
+
+    assert response.status_code == 200
+    assert response.headers.get("Content-Type") == "application/json"
+    assert response.json() == {"ok": True}

--- a/tests/integration/test_ingress.py
+++ b/tests/integration/test_ingress.py
@@ -112,5 +112,5 @@ async def test_ingress_media_integration(app_integrated: Application, model: Mod
     )
 
     assert response.status_code == 200
-    assert response.headers.get("Content-Type") == "application/json"
+    assert response.headers.get("Content-Type") == "application/json; charset=utf-8"
     assert response.json() == {"ok": True}

--- a/tests/integration/test_ingress.py
+++ b/tests/integration/test_ingress.py
@@ -76,7 +76,7 @@ async def test_ingress_media_integration(app_integrated: Application, model: Mod
     unit_address = unit_address.removeprefix("http://")
     response = requests.get(f"http://{unit_address}:11111/health", timeout=30)
     assert response.status_code == 200
-    assert response.headers.get("Content-Type") == "application/json"
+    assert response.headers.get("Content-Type") == "application/json; charset=utf-8"
     assert response.json() == {"ok": True}
     haproxy_application = await model.deploy(
         "haproxy", application_name="haproxy-media", channel="2.8/edge"

--- a/tests/integration/test_ingress.py
+++ b/tests/integration/test_ingress.py
@@ -43,7 +43,7 @@ async def test_ingress_integration(app_integrated: Application, model: Model):
     await model.wait_for_idle(
         apps=[self_signed_application.name, haproxy_application.name], status="active"
     )
-    await model.add_relation(app_integrated.name, haproxy_application.name)
+    await model.add_relation(f"{app_integrated.name}:ingress", haproxy_application.name)
     await model.wait_for_idle(
         apps=[app_integrated.name, haproxy_application.name], status="active"
     )
@@ -78,8 +78,14 @@ async def test_ingress_media_integration(app_integrated: Application, model: Mod
     assert response.status_code == 200
     assert response.headers.get("Content-Type") == "application/json"
     assert response.json() == {"ok": True}
-    haproxy_application = await model.deploy("haproxy", channel="2.8/edge")
-    self_signed_application = await model.deploy("self-signed-certificates", channel="edge")
+    haproxy_application = await model.deploy(
+        "haproxy", application_name="haproxy-media", channel="2.8/edge"
+    )
+    self_signed_application = await model.deploy(
+        "self-signed-certificates",
+        application_name="self-signed-certificates-media",
+        channel="edge",
+    )
     external_hostname = "haproxy-media.internal"
     await haproxy_application.set_config({"external-hostname": external_hostname})
     await model.wait_for_idle(

--- a/tests/unit/test_irc.py
+++ b/tests/unit/test_irc.py
@@ -70,10 +70,10 @@ def test_reconcile_calls_prepare_configure_and_reload_methods(irc_bridge_service
     )
 
     url = "http://localhost:8090"
-    irc_bridge_service.reconcile(db, matrix, config, url)
+    irc_bridge_service.reconcile(db, matrix, config, url, "10.10.10.10")
 
     mock_prepare.assert_called_once()
-    mock_configure.assert_called_once_with(db, matrix, config, url)
+    mock_configure.assert_called_once_with(db, matrix, config, url, "10.10.10.10")
     mock_reload.assert_called_once()
 
 
@@ -332,7 +332,9 @@ def test_configure_evaluates_configuration_file_local(irc_bridge_service, mocker
         bridge_admins="admin1:example.com,admin2:example.com",
     )
 
-    irc_bridge_service._eval_conf_local(db, matrix, config)  # pylint: disable=protected-access
+    irc_bridge_service._eval_conf_local(  # pylint: disable=protected-access
+        db, matrix, config, "10.10.10.10"
+    )
 
     calls = [
         mocker.call(f"{IRC_BRIDGE_CONFIG_FILE_PATH.absolute()}", "r", encoding="utf-8"),


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Add an ingress to the IRC Bridge media proxy. If ingress is not available,the  media proxy is set with the unit IP address (same as we do for the existing ingress)

### Rationale

When a matrix user shares a media file in a bridged room, IRC bridge displays it as a URL to IRC users. This URL is a proxy provided by IRC bridge to Matrix server and should be exposed.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
