### PR TITLE
Observe ingress-media relation events

### DIFF
--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -4,8 +4,10 @@
 """Unit tests for the IRC Bridge charm."""
 
 # Ignore similar lines with database_observer.
-# pylint: disable=R0801
+# Ignore access to _get_media_external_url.
+# pylint: disable=R0801, protected-access
 
+import json
 from unittest.mock import MagicMock
 
 import ops
@@ -47,3 +49,44 @@ def test_irc_bridge_ident(monkeypatch: MonkeyPatch) -> None:
 
     assert isinstance(harness.model.unit.status, ops.ActiveStatus)
     assert ops.Port(protocol="tcp", port=IDENT_PORT) in harness.model.unit.opened_ports()
+
+
+def test_ingress_media_removed(monkeypatch: MonkeyPatch) -> None:
+    """
+    arrange: start the charm with all integrations and commands mocked.
+    act: remove ingress-media relation.
+    assert: The media url points to the unit IP.
+    """
+    harness = Harness(IRCCharm)
+    harness.set_model_name("testmodel")
+    harness.add_network("10.0.0.10")
+    media_url = "https://media/"
+    ingress_id = harness.add_relation(
+        "ingress-media", "haproxy", app_data={"ingress": json.dumps({"url": media_url})}
+    )
+    harness.add_relation("matrix-auth", "synapse", app_data={"homeserver": "123"})
+    harness.add_relation(
+        "database",
+        "database-provider",
+        app_data={
+            "database": "ircbridge",
+            "endpoints": "postgresql-k8s-primary.local:5432",
+            "password": "123",
+            "username": "user1",
+        },
+    )
+    harness.begin()
+    mock_irc = MagicMock()
+    monkeypatch.setattr(harness.charm, "_irc", mock_irc)
+    monkeypatch.setattr(harness.charm, "_matrix", MagicMock())
+    harness.set_leader(True)
+    harness.update_config({"bot_nickname": "testbot", "bridge_admins": "admin:example.com"})
+    assert isinstance(harness.model.unit.status, ops.ActiveStatus)
+    assert harness.charm._get_media_external_url() == media_url
+
+    harness.remove_relation(ingress_id)
+
+    assert harness.charm._get_media_external_url() == "http://10.0.0.10:11111"
+    # when running update_config
+    # when remove ingress-media relation
+    assert mock_irc.reconcile.call_count == 2


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Since IRC configuration uses ingress-media URL information, the charm should observe events and then reconcile the configuration file.

### Rationale

Render configuration file properly.

### Juju Events Changes

ingress-media-changed
ingress-media-departed

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
