### PR TITLE
Add ingress media test using ops.testing

### DIFF
--- a/src/database_observer.py
+++ b/src/database_observer.py
@@ -61,7 +61,6 @@ class DatabaseObserver(Object):
                 fields=["uris", "endpoints", "username", "password", "database"]
             ).values()
         )
-
         if not relation_data:
             return None
 

--- a/src/database_observer.py
+++ b/src/database_observer.py
@@ -61,6 +61,7 @@ class DatabaseObserver(Object):
                 fields=["uris", "endpoints", "username", "password", "database"]
             ).values()
         )
+
         if not relation_data:
             return None
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -149,3 +149,5 @@ def test_ingress_media(monkeypatch: MonkeyPatch):
 
     assert out.unit_status == testing.ActiveStatus()
     assert mock_irc.reconcile.call_count == 2
+    args, _ = mock_irc.reconcile.call_args
+    assert args[0].media_external_url == media_url

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -8,9 +8,10 @@
 # pylint: disable=R0801, protected-access
 
 import json
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import ops
+from ops import testing
 from ops.testing import Harness
 from pytest import MonkeyPatch
 
@@ -90,3 +91,63 @@ def test_ingress_media_removed(monkeypatch: MonkeyPatch) -> None:
     # when running update_config
     # when remove ingress-media relation
     assert mock_irc.reconcile.call_count == 2
+
+
+def test_ingress_media():
+    """
+    arrange: start the charm with all integrations and commands mocked.
+    act: add ingress-media relation.
+    assert: The media url points to the ingress relation data URL.
+    """
+    mock_irc = MagicMock()
+    with patch(
+        "charm.IRCBridgeService",
+        return_value=mock_irc,
+    ), patch("charm.MatrixObserver", return_value=MagicMock()):
+        ctx = testing.Context(IRCCharm)
+        config = {"bot_nickname": "testbot", "bridge_admins": "admin:example.com"}
+        database_data = {
+            "database": "ircbridge",
+            "endpoints": "postgresql-k8s-primary.local:5432",
+            "password": "123",
+            "username": "user1",
+        }
+        matrix_auth_data = {"shared_secret_id": "123", "homeserver": "https://example.com/"}
+        relations = [
+            testing.Relation(
+                id=1,
+                endpoint="database",
+                interface="postgresql_client",
+                remote_app_data=database_data,
+            ),
+            testing.Relation(
+                id=2,
+                endpoint="matrix-auth",
+                interface="matrix_auth",
+                remote_app_data=matrix_auth_data,
+            ),
+        ]
+        secrets = [testing.Secret(id="123", tracked_content={"shared-secret-content": "abc"})]
+        state = testing.State(leader=True, config=config, relations=relations, secrets=secrets)
+        out = ctx.run(ctx.on.config_changed(), state)
+        assert out.unit_status == testing.ActiveStatus()
+        assert mock_irc.reconcile.called
+        args, _ = mock_irc.reconcile.call_args
+        assert args[0].media_external_url == "http://192.0.2.0:11111"
+
+        media_url = "https://media/"
+        relations.append(
+            testing.Relation(
+                id=3,
+                endpoint="ingress-media",
+                interface="ingress",
+                remote_app_data={"ingress": json.dumps({"url": media_url})},
+            )
+        )
+        state = testing.State(leader=True, config=config, relations=relations, secrets=secrets)
+        out = ctx.run(ctx.on.config_changed(), state)
+
+        assert out.unit_status == testing.ActiveStatus()
+        assert mock_irc.reconcile.called
+        args, _ = mock_irc.reconcile.call_args
+        assert args[0].media_external_url == media_url

--- a/tox.ini
+++ b/tox.ini
@@ -74,6 +74,7 @@ deps =
     coverage[toml]
     pytest
     pytest-mock
+    ops[testing]
     -r{toxinidir}/requirements.txt
 commands =
     coverage run --source={[vars]src_path},{[vars]lib_path} \


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Follow-up PR to https://github.com/canonical/irc-bridge-operator/pull/38
This PR adds a unit test for ingress-media using ops-testing (old Scenario)

### Rationale

Get used to writing testing in ops.testing instead of Harness.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
