### PR TITLE
Add wait_for_idle before setting config in test_ingress.py

### DIFF
--- a/tests/integration/test_ingress.py
+++ b/tests/integration/test_ingress.py
@@ -33,7 +33,7 @@ async def test_ingress_integration(app_integrated: Application, model: Model):
     assert response.status_code == 200
     assert response.text == "OK"
     haproxy_application = await model.deploy("haproxy", channel="2.8/edge")
-    self_signed_application = await model.deploy("self-signed-certificates", channel="edge")
+    self_signed_application = await model.deploy("self-signed-certificates", channel="1/edge")
     await model.wait_for_idle(
         apps=[self_signed_application.name, haproxy_application.name],
         status="active",
@@ -90,7 +90,7 @@ async def test_ingress_media_integration(app_integrated: Application, model: Mod
     self_signed_application = await model.deploy(
         "self-signed-certificates",
         application_name="self-signed-certificates-media",
-        channel="edge",
+        channel="1/edge",
     )
     external_hostname = "haproxy-media.internal"
     await model.wait_for_idle(

--- a/tests/integration/test_ingress.py
+++ b/tests/integration/test_ingress.py
@@ -34,6 +34,11 @@ async def test_ingress_integration(app_integrated: Application, model: Model):
     assert response.text == "OK"
     haproxy_application = await model.deploy("haproxy", channel="2.8/edge")
     self_signed_application = await model.deploy("self-signed-certificates", channel="edge")
+    await model.wait_for_idle(
+        apps=[self_signed_application.name, haproxy_application.name]],
+        status="active",
+        raise_on_error=True,
+    )
     external_hostname = "haproxy.internal"
     await haproxy_application.set_config({"external-hostname": external_hostname})
     await model.wait_for_idle(
@@ -87,6 +92,11 @@ async def test_ingress_media_integration(app_integrated: Application, model: Mod
         channel="edge",
     )
     external_hostname = "haproxy-media.internal"
+    await model.wait_for_idle(
+        apps=[self_signed_application.name, haproxy_application.name]],
+        status="active",
+        raise_on_error=True,
+    )
     await haproxy_application.set_config({"external-hostname": external_hostname})
     await model.wait_for_idle(
         apps=[self_signed_application.name, haproxy_application.name], status="active"

--- a/tests/integration/test_ingress.py
+++ b/tests/integration/test_ingress.py
@@ -38,19 +38,20 @@ async def test_ingress_integration(app_integrated: Application, model: Model):
         apps=[self_signed_application.name, haproxy_application.name],
         status="active",
         raise_on_error=True,
+        timeout=300,
     )
     external_hostname = "haproxy.internal"
     await haproxy_application.set_config({"external-hostname": external_hostname})
     await model.wait_for_idle(
-        apps=[self_signed_application.name, haproxy_application.name], status="active"
+        apps=[self_signed_application.name, haproxy_application.name], status="active", timeout=300
     )
     await model.add_relation(self_signed_application.name, haproxy_application.name)
     await model.wait_for_idle(
-        apps=[self_signed_application.name, haproxy_application.name], status="active"
+        apps=[self_signed_application.name, haproxy_application.name], status="active", timeout=300
     )
     await model.add_relation(f"{app_integrated.name}:ingress", haproxy_application.name)
     await model.wait_for_idle(
-        apps=[app_integrated.name, haproxy_application.name], status="active"
+        apps=[app_integrated.name, haproxy_application.name], status="active", timeout=300
     )
 
     unit_address = await tests.integration.helpers.get_unit_address(haproxy_application)
@@ -96,18 +97,19 @@ async def test_ingress_media_integration(app_integrated: Application, model: Mod
         apps=[self_signed_application.name, haproxy_application.name],
         status="active",
         raise_on_error=True,
+        timeout=300,
     )
     await haproxy_application.set_config({"external-hostname": external_hostname})
     await model.wait_for_idle(
-        apps=[self_signed_application.name, haproxy_application.name], status="active"
+        apps=[self_signed_application.name, haproxy_application.name], status="active", timeout=300
     )
     await model.add_relation(self_signed_application.name, haproxy_application.name)
     await model.wait_for_idle(
-        apps=[self_signed_application.name, haproxy_application.name], status="active"
+        apps=[self_signed_application.name, haproxy_application.name], status="active", timeout=300
     )
     await model.add_relation(f"{app_integrated.name}:ingress-media", haproxy_application.name)
     await model.wait_for_idle(
-        apps=[app_integrated.name, haproxy_application.name], status="active"
+        apps=[app_integrated.name, haproxy_application.name], status="active", timeout=300
     )
 
     unit_address = await tests.integration.helpers.get_unit_address(haproxy_application)

--- a/tests/integration/test_ingress.py
+++ b/tests/integration/test_ingress.py
@@ -35,7 +35,7 @@ async def test_ingress_integration(app_integrated: Application, model: Model):
     haproxy_application = await model.deploy("haproxy", channel="2.8/edge")
     self_signed_application = await model.deploy("self-signed-certificates", channel="edge")
     await model.wait_for_idle(
-        apps=[self_signed_application.name, haproxy_application.name]],
+        apps=[self_signed_application.name, haproxy_application.name],
         status="active",
         raise_on_error=True,
     )
@@ -93,7 +93,7 @@ async def test_ingress_media_integration(app_integrated: Application, model: Mod
     )
     external_hostname = "haproxy-media.internal"
     await model.wait_for_idle(
-        apps=[self_signed_application.name, haproxy_application.name]],
+        apps=[self_signed_application.name, haproxy_application.name],
         status="active",
         raise_on_error=True,
     )


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Fix integration test.

### Rationale

Add wait before the config.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
