### PR TITLE
Re-check Vale and fix errors

### DIFF
--- a/.custom_wordlist.txt
+++ b/.custom_wordlist.txt
@@ -1,4 +1,6 @@
+homeserver
 Ident
+Identd
 IRC
 misconfigurations
 rebasing

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
+<!-- vale Canonical.007-Headings-sentence-case = NO -->
 # IRC Bridge Operator
+<!-- vale Canonical.007-Headings-sentence-case = YES -->
 
 A [Juju](https://juju.is/) [charm](https://documentation.ubuntu.com/juju/3.6/reference/charm/)
 deploying and managing an IRC Bridge (with Ident server) Integrator on bare metal.
@@ -6,7 +8,9 @@ deploying and managing an IRC Bridge (with Ident server) Integrator on bare meta
 This charm is meant to be used in conjunction with [Synapse](https://github.com/canonical/synapse-operator) and related
 to it.
 
+<!-- vale Canonical.007-Headings-sentence-case = NO -->
 ## High-level overview of IRC Bridge
+<!-- vale Canonical.007-Headings-sentence-case = YES -->
 
 The IRC Bridge is implemented as an Application Service, as defined in the Matrix
 specification. This means it interacts with Synapse through the Application

--- a/docs/explanation/charm-architecture.md
+++ b/docs/explanation/charm-architecture.md
@@ -32,7 +32,9 @@ Snap and generates the necessary configuration.
 7. From the Matrix authentication integration, the Charm creates the IRC
 registration file and shares it with Synapse, which then registers the IRC Bridge as an application service.
 
+<!-- vale Canonical.007-Headings-sentence-case = NO -->
 ## IRC bridge snap
+<!-- vale Canonical.007-Headings-sentence-case = YES -->
 
 The IRC Bridge Snap is utilized to package and distribute [matrix-appservice-irc](https://github.com/matrix-org/matrix-appservice-irc),
 providing a consistent, secure and maintainable deployment across various

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,6 @@
+<!-- vale Canonical.007-Headings-sentence-case = NO -->
 # IRC Bridge Operator
+<!-- vale Canonical.007-Headings-sentence-case = YES -->
 
 A [Juju](https://juju.is/) [charm](https://documentation.ubuntu.com/juju/3.6/reference/charm/)
 deploying and managing an IRC Bridge (with Ident server) Integrator on bare metal.
@@ -6,7 +8,9 @@ deploying and managing an IRC Bridge (with Ident server) Integrator on bare meta
 This charm is meant to be used in conjunction with [Synapse](https://github.com/canonical/synapse-operator) and related
 to it.
 
+<!-- vale Canonical.007-Headings-sentence-case = NO -->
 ## High-level overview of IRC Bridge
+<!-- vale Canonical.007-Headings-sentence-case = YES -->
 
 The IRC Bridge is implemented as an Application Service, as defined in the Matrix
 specification. This means it interacts with Synapse through the Application

--- a/docs/tutorial/deploy-irc-bridge.md
+++ b/docs/tutorial/deploy-irc-bridge.md
@@ -1,4 +1,6 @@
+<!-- vale Canonical.007-Headings-sentence-case = NO -->
 # Deploy IRC bridge
+<!-- vale Canonical.007-Headings-sentence-case = YES -->
 
 In this tutorial, we will deploy IRC Bridge, add configurations and integrate it
 with other charms to set up a working Matrix application.
@@ -26,7 +28,9 @@ your usual work, create a new model using the following command.
 juju add-model irc-bridge-tutorial
 ```
 
+<!-- vale Canonical.007-Headings-sentence-case = NO -->
 ### Deploy IRC bridge
+<!-- vale Canonical.007-Headings-sentence-case = YES -->
 
 ```
 juju deploy irc-bridge --channel edge
@@ -35,7 +39,9 @@ juju deploy irc-bridge --channel edge
 The tutorial uses the edge channel to get the latest updates on the
 Matrix-Auth library.
 
+<!-- vale Canonical.007-Headings-sentence-case = NO -->
 ### Configure IRC bridge
+<!-- vale Canonical.007-Headings-sentence-case = YES -->
 
 IRC Bridge has two mandatory configurations:
 
@@ -112,7 +118,9 @@ applications to integrate with it.
 juju offer synapse:matrix-auth
 ```
 
+<!-- vale Canonical.007-Headings-sentence-case = NO -->
 ### Integrate IRC bridge with Synapse
+<!-- vale Canonical.007-Headings-sentence-case = YES -->
 
 Now that the user used by IRC is created and the offer is available, change it
 back to the LXD controller to integrate IRC Bridge and Synapse.
@@ -166,7 +174,9 @@ Screenshot example:
 
 ![irc-screenshot|690x575](upload://p4AjA75vPFwTcKWKWrzS25eFWEG.jpeg)
 
+<!-- vale Canonical.007-Headings-sentence-case = NO -->
 ### Join a IRC channel
+<!-- vale Canonical.007-Headings-sentence-case = YES -->
 
 You can send a message to the user `ircappservice` like `!join #python` and
 this will be interpreted as a command to join the #python channel.


### PR DESCRIPTION
Applicable ticket: ISD-3949

### Overview

Run Vale checks locally and fix errors.

### Rationale

There's a bug in operator-workflows that points to an older version of the Canonical Vale style checks. Therefore some of the checks will be missed in the GitHub CI.

### Juju Events Changes

None

### Module Changes

None

### Library Changes

None

### Checklist

- [X] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [X] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [X] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated
- [X] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
There are no `src` docs.
Either discourse-gatekeeper will update the documentation on Charmhub or I'll do it after the approval of this PR.
